### PR TITLE
Fix bug grecaptcha is undefined

### DIFF
--- a/truyenYY_downloader/truyenYY_downloader.user.js
+++ b/truyenYY_downloader/truyenYY_downloader.user.js
@@ -26,7 +26,7 @@
 // @grant           GM_xmlhttpRequest
 // @grant           GM.xmlHttpRequest
 // @grant           GM_addStyle
-// @inject-into     content
+// @inject-into     auto
 // ==/UserScript==
 
 (function ($, window, document) {
@@ -363,7 +363,7 @@
     e.preventDefault();
     document.title = '[...] Vui lòng chờ trong giây lát';
 
-    var firstChap = $('.info .btn:contains("Đọc Từ Đầu"), #root_novel_buttons .weui-btn:contains("Đọc Từ Đầu")');
+    var firstChap = $('.info .btn:contains("Đọc Từ Đầu"), #root_novel_buttons .weui-btn:contains("Đọc Từ Đầu"), .weui-btn:contains("Đọc Tiếp")');
     firstChap = downloadId(firstChap.attr('href'));
     var startFrom = firstChap;
 


### PR DESCRIPTION
Downloading a vip content require grecaptcha but after getting script the object return null most of the times. However, while checking window.grecaptcha object, it's loaded. This might be due to the permission grant so I've changed it to auto instead of content.
Besides, right click does not work, and it's not always have "Đọc Từ Đầu" string, I've made a minor update on this too.